### PR TITLE
[DO NOT MERGE] autofix-pr 실험용 — 의도적 테스트 실패

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,35 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+       (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707  # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/app/src/test/java/com/choo/moviefinder/data/repository/BackupRepositoryImplTest.kt
+++ b/app/src/test/java/com/choo/moviefinder/data/repository/BackupRepositoryImplTest.kt
@@ -85,7 +85,7 @@ class BackupRepositoryImplTest {
         assertEquals(1, backup.favorites.size)
         assertEquals(1, backup.favorites[0].id)
         assertEquals("Test Movie", backup.favorites[0].title)
-        assertEquals(9999L, backup.favorites[0].addedAt) // intentional failure for autofix-pr test
+        assertEquals(1000L, backup.favorites[0].addedAt)
     }
 
     @Test

--- a/app/src/test/java/com/choo/moviefinder/data/repository/BackupRepositoryImplTest.kt
+++ b/app/src/test/java/com/choo/moviefinder/data/repository/BackupRepositoryImplTest.kt
@@ -85,7 +85,7 @@ class BackupRepositoryImplTest {
         assertEquals(1, backup.favorites.size)
         assertEquals(1, backup.favorites[0].id)
         assertEquals("Test Movie", backup.favorites[0].title)
-        assertEquals(1000L, backup.favorites[0].addedAt)
+        assertEquals(9999L, backup.favorites[0].addedAt) // intentional failure for autofix-pr test
     }
 
     @Test


### PR DESCRIPTION
## ⚠️ 실험용 PR — Merge 금지

`/autofix-pr` 기능 테스트를 위해 의도적으로 테스트를 실패시킨 PR입니다.

## 실패 내용

`BackupRepositoryImplTest.exportUserData maps favorites correctly`
- 기대값: `1000L`
- 실제 assertion: `9999L` (의도적으로 틀린 값)

CI `build` job의 테스트 단계에서 실패할 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)